### PR TITLE
Add Bottom screen only mode

### DIFF
--- a/app/includes/Logger.hpp
+++ b/app/includes/Logger.hpp
@@ -17,6 +17,9 @@ public:
     void Warning(const char* fmt, ...);
     void Error(const char* fmt, ...);
     void Traffic(const char* fmt, ...);
+    void BrokenScreen(); // Usually some 3DSes have a broken top screen, important information
+                        // should be displayed on the bottom screen instead.
+    bool GetOverrideState() { return overrideTop; }
 
     void Wait();
 
@@ -39,6 +42,7 @@ private:
     void Handler();
     Thread thread;
     LightEvent event;
+    bool overrideTop = false;
     
     std::queue<PendingLog> pendingLogs;
     CTRPluginFramework::Mutex pendingLogsMutex;

--- a/app/sources/Logger.cpp
+++ b/app/sources/Logger.cpp
@@ -51,7 +51,7 @@ void Logger::Info(const char* fmt, ...) {
     if (ret >= 0) buffer[ret] = '\0';
     {
         CTRPluginFramework::Lock l(pendingLogsMutex);
-        pendingLogs.push(PendingLog{.type = PendingLog::Type::INFO, .isTopScr = true, .string{buffer}});
+        pendingLogs.push(PendingLog{.type = PendingLog::Type::INFO, .isTopScr = (overrideTop ? false : true), .string{buffer}});
     }
     LightEvent_Signal(&event);
 }
@@ -66,7 +66,7 @@ void Logger::Debug(const char* fmt, ...) {
     if (ret >= 0) buffer[ret] = '\0';
     {
         CTRPluginFramework::Lock l(pendingLogsMutex);
-        pendingLogs.push(PendingLog{.type = PendingLog::Type::DEBUG, .isTopScr = true, .string{buffer}});
+        pendingLogs.push(PendingLog{.type = PendingLog::Type::DEBUG, .isTopScr = (overrideTop ? false : true), .string{buffer}});
     }
     LightEvent_Signal(&event);
 }
@@ -80,7 +80,7 @@ void Logger::Warning(const char* fmt, ...) {
     if (ret >= 0) buffer[ret] = '\0';
     {
         CTRPluginFramework::Lock l(pendingLogsMutex);
-        pendingLogs.push(PendingLog{.type = PendingLog::Type::WARNING, .isTopScr = true, .string{buffer}});
+        pendingLogs.push(PendingLog{.type = PendingLog::Type::WARNING, .isTopScr = (overrideTop ? false : true), .string{buffer}});
     }
     LightEvent_Signal(&event);
 }
@@ -94,7 +94,7 @@ void Logger::Error(const char* fmt, ...) {
     if (ret >= 0) buffer[ret] = '\0';
     {
         CTRPluginFramework::Lock l(pendingLogsMutex);
-        pendingLogs.push(PendingLog{.type = PendingLog::Type::ERROR, .isTopScr = true, .string{buffer}});
+        pendingLogs.push(PendingLog{.type = PendingLog::Type::ERROR, .isTopScr = (overrideTop ? false : true), .string{buffer}});
     }
     LightEvent_Signal(&event);
 }
@@ -111,6 +111,10 @@ void Logger::Traffic(const char* fmt, ...) {
         pendingLogs.push(PendingLog{.type = PendingLog::Type::TRAFFIC, .isTopScr = false, .string{buffer}});
     }
     LightEvent_Signal(&event);
+}
+
+void Logger::BrokenScreen() {
+    overrideTop = !overrideTop;
 }
 
 void Logger::Handler() {

--- a/app/sources/main.cpp
+++ b/app/sources/main.cpp
@@ -158,6 +158,7 @@ void Main() {
     }
     logger.Raw(false, "\n             ArticBase v%d.%d.%d\n", VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION);
     logger.Raw(false, "    Press A to launch Artic Base.");
+    logger.Raw(false, "    Press L to enable logs at the bottom\n    (useful for broken top screens).");
     logger.Raw(false, "    Press B or START to exit.");
     logger.Raw(true, "");
     logger.Info("Welcome to Artic Base!\n    Check bottom screen for controls.");
@@ -174,12 +175,18 @@ void Main() {
             break;
         }
 
+        if (kDown & (KEY_L)) {
+        logger.BrokenScreen();
+	    logger.Info("Logs will be written here.");
+        }
+
         if (kDown & KEY_A) {
             logger.Info("Launching Artic Base");
             bool done = extractPlugin() && launchPlugin();
             if (done) {
                 logger.Raw(true, "");
                 logger.Info("Done, select a game from the home menu");
+                if (logger.GetOverrideState()) logger.Warning("Hold [L] to enable logs on the\n bottom screen !");
                 svcSleepThread(3000000000);
                 break;
             } else {

--- a/plugin/sources/main.cpp
+++ b/plugin/sources/main.cpp
@@ -177,6 +177,7 @@ PrintConsole topScreenConsole, bottomScreenConsole;
 void Main() {
     logger.Start();
 
+
     plgLdrInit();
     bool prevPluginState = ((PluginHeader*)0x07000000)->config[0] != 0;
     PLGLDR__SetPluginLoaderState(prevPluginState);
@@ -234,7 +235,15 @@ void Main() {
             
         }
     };
-    
+
+	hidScanInput();
+    u32 kH = hidKeysHeld();
+    if (kH & KEY_L) {
+        logger.BrokenScreen();
+        logger.Info("\n\n\n\n\n\n\n\n   Bottom screen mode.");
+    }
+
+
     print_bottom_info(false);
     logger.Raw(true, "");
 


### PR DESCRIPTION
On the app mode press L to enable bottom screen logs.
On the plugin mode hold L while booting a game to enable bottom screen.

Since this isn't supposed to be a main feature but rather a "hack" for some users who happen to want to use the plugin and have a broken top screen (fairly frequent on o3DS XL apparently), this would be useful for them and would further reduce e-waste potential.

closes #56 (although does not exactly change screens)